### PR TITLE
BitBucket git repo fix

### DIFF
--- a/models/GitHooks.cfc
+++ b/models/GitHooks.cfc
@@ -49,6 +49,9 @@ component {
     }
 
     function install( callback ) {
+        if ( !directoryExists(variables.hooksDirectory) ) {
+            directoryCreate( variables.hooksDirectory );
+        }
         for ( var key in variables.availableHooks ) {
             var hookName = variables.availableHooks[ key ];
             var template = fileRead( expandPath( "/commandbox-githooks/resources/hook-template") );

--- a/models/GitHooks.cfc
+++ b/models/GitHooks.cfc
@@ -49,9 +49,10 @@ component {
     }
 
     function install( callback ) {
-        if ( !directoryExists(variables.hooksDirectory) ) {
+        if ( ! directoryExists( variables.hooksDirectory ) ) {
             directoryCreate( variables.hooksDirectory );
         }
+        
         for ( var key in variables.availableHooks ) {
             var hookName = variables.availableHooks[ key ];
             var template = fileRead( expandPath( "/commandbox-githooks/resources/hook-template") );


### PR DESCRIPTION
In bitbucket git repos the "hooks" folder does not exist initially. This checks to see if the hooks folder is there before attempting to create the nested files. If not, then it is created.